### PR TITLE
update agile_user_story_conformance.py to work with Spacy 3.0

### DIFF
--- a/agile_user_story_conformance.py
+++ b/agile_user_story_conformance.py
@@ -30,7 +30,7 @@ class AgileUserStoryParser:
         return doc
 
     def check_conformance(self):
-        matcher.add("UserStory", None, user_story)
+        matcher.add("UserStory", [user_story], on_match = None)
         matches = matcher(self.sent.as_doc())
         #logging.debug(len(matches), matches)
         if matches:


### PR DESCRIPTION
update line 33 to work with Spacy 3.0, where Matcher.add now takes the pattern list as the 2nd arguement and on_match, becomes an optional KWArg.
Wrapped the pattern as a list [user_story]. (not sure why this is needed, as user_story is a list of dicts already, but it doesn't function without it)